### PR TITLE
Rewrite to use non-exhaustive structs, enums and builders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 [[package]]
 name = "base64uuid"
 version = "1.0.0-alpha.2"
-source = "git+ssh://git@github.com/fiberplane/fiberplane-rs.git?branch=main#c85835b6ba826f0518e86ae43fbbaea734e66636"
+source = "git+ssh://git@github.com/fiberplane/fiberplane-rs.git?branch=main#f90c6cbfd75d5ceb4e3be12cd81aaedf7b445446"
 dependencies = [
  "base64",
  "serde",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "cloudwatch-provider"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "base64",
  "bytes",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "fiberplane-models"
 version = "1.0.0-alpha.2"
-source = "git+ssh://git@github.com/fiberplane/fiberplane-rs.git?branch=main#c85835b6ba826f0518e86ae43fbbaea734e66636"
+source = "git+ssh://git@github.com/fiberplane/fiberplane-rs.git?branch=main#f90c6cbfd75d5ceb4e3be12cd81aaedf7b445446"
 dependencies = [
  "base64",
  "base64uuid",
@@ -277,12 +277,13 @@ dependencies = [
  "strum_macros",
  "thiserror",
  "time",
+ "typed-builder",
  "url",
 ]
 
 [[package]]
 name = "fiberplane-pdk"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "fiberplane-models",
  "fiberplane-pdk-macros",
@@ -298,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "fiberplane-pdk-macros"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "Inflector",
  "fiberplane-models",
@@ -311,7 +312,7 @@ dependencies = [
 [[package]]
 name = "fiberplane-provider-bindings"
 version = "2.0.0-alpha.1"
-source = "git+ssh://git@github.com/fiberplane/fiberplane-rs.git?branch=main#c85835b6ba826f0518e86ae43fbbaea734e66636"
+source = "git+ssh://git@github.com/fiberplane/fiberplane-rs.git?branch=main#f90c6cbfd75d5ceb4e3be12cd81aaedf7b445446"
 dependencies = [
  "bytes",
  "fiberplane-models",
@@ -975,7 +976,7 @@ checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "sample-provider"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "fiberplane-pdk",
  "serde",
@@ -1229,6 +1230,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6179333b981641242a768f30f371c9baccbfcc03749627000c500ab88bf4528b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["providers/.cargo"]
 authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2021"
 rust-version = "1.65"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/fiberplane-pdk/src/provider_data.rs
+++ b/fiberplane-pdk/src/provider_data.rs
@@ -54,14 +54,14 @@ pub fn parse_blob<T: DeserializeOwned>(mime_type: &str, blob: Blob) -> Result<T>
 /// struct's `serialize()` method.
 pub fn to_blob<T: Serialize>(mime_type: &str, data: &T) -> Result<Blob> {
     if cfg!(debug_assertions) {
-        Ok(Blob {
-            data: serde_json::to_vec(data)?.into(),
-            mime_type: format!("{mime_type}+json"),
-        })
+        Ok(Blob::builder()
+            .data(serde_json::to_vec(data)?)
+            .mime_type(format!("{mime_type}+json"))
+            .build())
     } else {
-        Ok(Blob {
-            data: rmp_serde::to_vec_named(data)?.into(),
-            mime_type: format!("{mime_type}+msgpack"),
-        })
+        Ok(Blob::builder()
+            .data(rmp_serde::to_vec_named(data)?)
+            .mime_type(format!("{mime_type}+msgpack"))
+            .build())
     }
 }

--- a/providers/cloudwatch/src/client.rs
+++ b/providers/cloudwatch/src/client.rs
@@ -90,12 +90,12 @@ impl ClientCommon {
             format!("{}{}?{}", self.endpoint, uri, querystring)
         };
 
-        let request = HttpRequest {
-            url,
-            method,
-            headers: Some(headers.into_iter().collect()),
-            body: request.body.clone(),
-        };
+        let request = HttpRequest::builder()
+            .url(url)
+            .method(method)
+            .headers(Some(headers.into_iter().collect()))
+            .body(request.body.clone())
+            .build();
 
         log(format!("CloudWatch: Sending request {request:?}"));
 

--- a/providers/cloudwatch/src/queries.rs
+++ b/providers/cloudwatch/src/queries.rs
@@ -13,10 +13,10 @@ use fiberplane_pdk::prelude::{Blob, Cell, Error, Timestamp};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 pub fn serialize_cells(cells: Vec<Cell>) -> Result<Blob, Error> {
-    Ok(Blob {
-        data: rmp_serde::to_vec_named(&cells)?.into(),
-        mime_type: CELLS_MSGPACK_MIME_TYPE.to_owned(),
-    })
+    Ok(Blob::builder()
+        .data(rmp_serde::to_vec_named(&cells)?)
+        .mime_type(CELLS_MSGPACK_MIME_TYPE.to_owned())
+        .build())
 }
 
 pub fn try_from_iso_date(timestamp: &str) -> Result<Timestamp, Error> {

--- a/providers/cloudwatch/src/queries/auto_suggest.rs
+++ b/providers/cloudwatch/src/queries/auto_suggest.rs
@@ -31,10 +31,10 @@ pub async fn invoke2_handler(query_data: Blob, config: Config) -> Result<Blob> {
         }
     };
 
-    Ok(Blob {
-        data: rmp_serde::to_vec_named(&suggestions)?.into(),
-        mime_type: SUGGESTIONS_MSGPACK_MIME_TYPE.to_owned(),
-    })
+    Ok(Blob::builder()
+        .data(rmp_serde::to_vec_named(&suggestions)?)
+        .mime_type(SUGGESTIONS_MSGPACK_MIME_TYPE.to_owned())
+        .build())
 }
 
 async fn list_metrics_suggestions(
@@ -48,10 +48,12 @@ async fn list_metrics_suggestions(
             keys.retain(|k| k.contains(&query.query));
             Ok(keys
                 .into_iter()
-                .map(|k| Suggestion {
-                    from: Some(0),
-                    text: k,
-                    description: None,
+                .map(|k| {
+                    Suggestion::builder()
+                        .from(Some(0))
+                        .text(k)
+                        .description(None)
+                        .build()
                 })
                 .collect())
         }
@@ -63,10 +65,12 @@ async fn list_metrics_suggestions(
             values.retain(|v| v.contains(&query.query));
             Ok(values
                 .into_iter()
-                .map(|v| Suggestion {
-                    from: Some(0),
-                    text: v,
-                    description: None,
+                .map(|v| {
+                    Suggestion::builder()
+                        .from(Some(0))
+                        .text(v)
+                        .description(None)
+                        .build()
                 })
                 .collect())
         }
@@ -92,12 +96,15 @@ async fn list_log_query_suggestions(
 
             Ok(keys
                 .into_iter()
-                .map(|k| Suggestion {
-                    from: Some(from.try_into().unwrap()),
-                    text: k
-                        .log_group_name
-                        .expect("All log groups returned by AWS have a name"),
-                    description: k.stored_bytes.map(|bytes| format!("{bytes} bytes")),
+                .map(|k| {
+                    Suggestion::builder()
+                        .from(Some(from.try_into().unwrap()))
+                        .text(
+                            k.log_group_name
+                                .expect("All log groups returned by AWS have a name"),
+                        )
+                        .description(k.stored_bytes.map(|bytes| format!("{bytes} bytes")))
+                        .build()
                 })
                 .collect())
         }
@@ -118,11 +125,13 @@ async fn list_log_query_suggestions(
                 .iter()
                 .filter_map(|(field, description)| {
                     if field.starts_with(&identifier) {
-                        Some(Suggestion {
-                            from: Some(from.try_into().unwrap()),
-                            text: field.to_string(),
-                            description: Some(description.to_string()),
-                        })
+                        Some(
+                            Suggestion::builder()
+                                .from(Some(from.try_into().unwrap()))
+                                .text(field.to_string())
+                                .description(Some(description.to_string()))
+                                .build(),
+                        )
                     } else {
                         None
                     }
@@ -162,12 +171,15 @@ async fn list_graph_metric_suggestions(
 
             Ok(keys
                 .into_iter()
-                .map(|k| Suggestion {
-                    from: Some(from.try_into().unwrap()),
-                    text: k
-                        .metric_name
-                        .expect("All metrics returned by AWS have a name"),
-                    description: k.namespace,
+                .map(|k| {
+                    Suggestion::builder()
+                        .from(Some(from.try_into().unwrap()))
+                        .text(
+                            k.metric_name
+                                .expect("All metrics returned by AWS have a name"),
+                        )
+                        .description(k.namespace)
+                        .build()
                 })
                 .unique_by(|suggestion| (suggestion.text.clone(), suggestion.description.clone()))
                 .collect())
@@ -177,10 +189,12 @@ async fn list_graph_metric_suggestions(
 
             Ok(values
                 .iter()
-                .map(|v| Suggestion {
-                    from: Some(0),
-                    text: v.to_string(),
-                    description: None,
+                .map(|v| {
+                    Suggestion::builder()
+                        .from(Some(0))
+                        .text(v.to_string())
+                        .description(None)
+                        .build()
                 })
                 .collect())
         }

--- a/providers/cloudwatch/src/queries/describe_log_groups.rs
+++ b/providers/cloudwatch/src/queries/describe_log_groups.rs
@@ -21,12 +21,14 @@ fn try_into_blob(groups: Vec<LogGroup>) -> Result<Blob> {
             .into_iter()
             .enumerate()
             .map(|(id, group)| {
-                Cell::Text(TextCell {
-                    id: format!("log-group-{id}"),
-                    content: format!("{group:#?}"),
-                    formatting: Vec::new(),
-                    read_only: Some(true),
-                })
+                Cell::Text(
+                    TextCell::builder()
+                        .id(format!("log-group-{id}"))
+                        .content(format!("{group:#?}"))
+                        .formatting(Vec::new())
+                        .read_only(true)
+                        .build(),
+                )
             })
             .collect(),
     )

--- a/providers/cloudwatch/src/queries/describe_queries.rs
+++ b/providers/cloudwatch/src/queries/describe_queries.rs
@@ -23,12 +23,14 @@ fn try_into_blob(groups: Vec<QueryInfo>) -> Result<Blob, Error> {
             .into_iter()
             .enumerate()
             .map(|(id, query)| {
-                Cell::Text(TextCell {
-                    id: format!("query-{id}"),
-                    content: format!("{query:#?}"),
-                    formatting: Vec::new(),
-                    read_only: Some(true),
-                })
+                Cell::Text(
+                    TextCell::builder()
+                        .id(format!("query-{id}"))
+                        .content(format!("{query:#?}"))
+                        .formatting(Vec::new())
+                        .read_only(true)
+                        .build(),
+                )
             })
             .collect(),
     )

--- a/providers/cloudwatch/src/queries/list_metrics.rs
+++ b/providers/cloudwatch/src/queries/list_metrics.rs
@@ -60,12 +60,14 @@ pub async fn invoke2_handler(config: Config, request: ProviderRequest) -> Result
 
 pub fn create_cells_handler(response: Blob) -> Result<Vec<Cell>, Error> {
     let list = MetricList::try_from_blob(response)?;
-    Ok(vec![Cell::Text(TextCell {
-        id: "metric-list".to_string(),
-        content: list.to_string(),
-        formatting: Vec::new(),
-        read_only: Some(true),
-    })])
+    Ok(vec![Cell::Text(
+        TextCell::builder()
+            .id("metric-list".to_string())
+            .content(list.to_string())
+            .formatting(Vec::new())
+            .read_only(true)
+            .build(),
+    )])
 }
 
 struct ListMetricsRequest {

--- a/providers/cloudwatch/src/queries/start_query.rs
+++ b/providers/cloudwatch/src/queries/start_query.rs
@@ -47,21 +47,23 @@ fn try_into_blob(id: String) -> Result<Blob, Error> {
         .try_into()
         .expect("usize fits in u32 on all target architectures.");
 
-    serialize_cells(vec![Cell::Text(TextCell {
-        id: "query-id".to_string(),
-        formatting: vec![
-            AnnotationWithOffset {
-                offset: link_start,
-                annotation: Annotation::StartLink { url },
-            },
-            AnnotationWithOffset {
-                offset: length,
-                annotation: Annotation::EndLink,
-            },
-        ],
-        content,
-        read_only: Some(true),
-    })])
+    serialize_cells(vec![Cell::Text(
+        TextCell::builder()
+            .id("query-id".to_string())
+            .formatting(vec![
+                AnnotationWithOffset::builder()
+                    .offset(link_start)
+                    .annotation(Annotation::StartLink { url })
+                    .build(),
+                AnnotationWithOffset::builder()
+                    .offset(length)
+                    .annotation(Annotation::EndLink)
+                    .build(),
+            ])
+            .content(content)
+            .read_only(true)
+            .build(),
+    )])
 }
 
 struct StartQueryInput {

--- a/providers/cloudwatch/src/queries/status.rs
+++ b/providers/cloudwatch/src/queries/status.rs
@@ -7,9 +7,11 @@ pub async fn check_status(config: Config) -> Result<Blob> {
     let blob = client
         .list_metrics(None, None, None, Some(0))
         .await
-        .map(|_| Blob {
-            mime_type: STATUS_MIME_TYPE.to_owned(),
-            data: "ok".into(),
+        .map(|_| {
+            Blob::builder()
+                .mime_type(STATUS_MIME_TYPE.to_owned())
+                .data("ok")
+                .build()
         })?;
     Ok(blob)
 }

--- a/providers/elasticsearch/src/lib.rs
+++ b/providers/elasticsearch/src/lib.rs
@@ -116,18 +116,18 @@ async fn fetch_logs(query: QueryLogs, config: Config) -> Result<Vec<LogRecord>> 
     let body = SearchRequestBody { size: query.limit };
     url.set_query(Some(&format!("q={}", &query_string)));
 
-    let request = HttpRequest {
-        body: Some(
+    let request = HttpRequest::builder()
+        .body(Some(
             serde_json::to_vec(&body)
                 .map_err(|e| Error::Data {
                     message: format!("Error serializing query: {e:?}"),
                 })?
                 .into(),
-        ),
-        headers: Some(headers),
-        method: HttpRequestMethod::Post,
-        url: url.to_string(),
-    };
+        ))
+        .headers(Some(headers))
+        .method(HttpRequestMethod::Post)
+        .url(url.to_string())
+        .build();
 
     // Parse response
     let response = make_http_request(request).await?.body;
@@ -294,12 +294,12 @@ async fn check_status(config: Config) -> Result<()> {
     let mut headers = HashMap::new();
     headers.insert("Content-Type".to_string(), "application/json".to_string());
 
-    let request = HttpRequest {
-        body: None,
-        headers: Some(headers),
-        method: HttpRequestMethod::Get,
-        url: url.to_string(),
-    };
+    let request = HttpRequest::builder()
+        .body(None)
+        .headers(Some(headers))
+        .method(HttpRequestMethod::Get)
+        .url(url.to_string())
+        .build();
 
     let _ = make_http_request(request).await?;
 

--- a/providers/grafana-common/src/lib.rs
+++ b/providers/grafana-common/src/lib.rs
@@ -75,19 +75,19 @@ where
     let request = if let Some(blob) = body {
         let mut headers = headers.unwrap_or_default();
         headers.insert("Content-Type".to_string(), blob.mime_type);
-        HttpRequest {
-            url,
-            headers: Some(headers),
-            method: HttpRequestMethod::Post,
-            body: Some(blob.data),
-        }
+        HttpRequest::builder()
+            .url(url)
+            .headers(Some(headers))
+            .method(HttpRequestMethod::Post)
+            .body(Some(blob.data))
+            .build()
     } else {
-        HttpRequest {
-            url,
-            headers,
-            method: HttpRequestMethod::Get,
-            body: None,
-        }
+        HttpRequest::builder()
+            .url(url)
+            .headers(headers)
+            .method(HttpRequestMethod::Get)
+            .body(None)
+            .build()
     };
 
     log(format!(
@@ -126,12 +126,14 @@ async fn get_grafana_datasource_proxy_url(
         .map_err(|e| Error::Config {
             message: format!("Invalid URL: {e:?}"),
         })?;
-    let response = make_http_request(HttpRequest {
-        body: None,
-        headers: config.to_headers(),
-        method: HttpRequestMethod::Get,
-        url: url.to_string(),
-    })
+    let response = make_http_request(
+        HttpRequest::builder()
+            .body(None)
+            .headers(config.to_headers())
+            .method(HttpRequestMethod::Get)
+            .url(url.to_string())
+            .build(),
+    )
     .await?;
     let data_sources: Vec<Datasource> =
         serde_json::from_slice(&response.body).map_err(|e| Error::Deserialization {

--- a/providers/https/src/lib.rs
+++ b/providers/https/src/lib.rs
@@ -133,12 +133,12 @@ async fn send_query(
         headers.insert("Content-Type".to_string(), blob.mime_type.clone());
     };
 
-    let request = HttpRequest {
-        url,
-        headers: Some(headers),
-        method,
-        body: body.map(|blob| blob.data),
-    };
+    let request = HttpRequest::builder()
+        .url(url)
+        .headers(Some(headers))
+        .method(method)
+        .body(body.map(|blob| blob.data))
+        .build();
     log(format!(
         "Sending {:?} request to {}",
         request.method, request.url
@@ -187,12 +187,12 @@ async fn handle_query(config: Config, request: ProviderRequest) -> Result<Blob> 
                 "GET" => method = HttpRequestMethod::Get,
                 unsupported => {
                     return Err(Error::ValidationError {
-                        errors: vec![ValidationError {
-                            field_name: HTTP_METHOD_PARAM_NAME.to_string(),
-                            message: format!(
+                        errors: vec![ValidationError::builder()
+                            .field_name(HTTP_METHOD_PARAM_NAME.to_string())
+                            .message(format!(
                                 "{unsupported} is not a supported HTTPS method with this provider."
-                            ),
-                        }],
+                            ))
+                            .build()],
                     })
                 }
             },
@@ -200,11 +200,13 @@ async fn handle_query(config: Config, request: ProviderRequest) -> Result<Blob> 
                 if let Some(ref api) = config.api {
                     if value.parse::<Url>().is_ok() {
                         return Err(Error::ValidationError {
-                            errors: vec![ValidationError {
-                                field_name: PATH_PARAM_NAME.to_string(),
-                                message: "a provider with a baseUrl cannot query arbitrary URLs"
-                                    .to_string(),
-                            }],
+                            errors: vec![ValidationError::builder()
+                                .field_name(PATH_PARAM_NAME.to_string())
+                                .message(
+                                    "a provider with a baseUrl cannot query arbitrary URLs"
+                                        .to_string(),
+                                )
+                                .build()],
                         });
                     }
                     url = Ok(api.base_url.clone());
@@ -222,10 +224,10 @@ async fn handle_query(config: Config, request: ProviderRequest) -> Result<Blob> 
                     url = Ok(full_url);
                 } else {
                     return Err(Error::ValidationError {
-                        errors: vec![ValidationError {
-                            field_name: PATH_PARAM_NAME.to_string(),
-                            message: format!("invalid url: {value:?}"),
-                        }],
+                        errors: vec![ValidationError::builder()
+                            .field_name(PATH_PARAM_NAME.to_string())
+                            .message(format!("invalid url: {value:?}"))
+                            .build()],
                     });
                 }
             }

--- a/providers/https/src/provider_response.rs
+++ b/providers/https/src/provider_response.rs
@@ -74,37 +74,49 @@ impl HttpsProviderResponse {
     }
 
     fn text_cell(id: String, content: String) -> Cell {
-        Cell::Text(TextCell {
-            id,
-            content,
-            formatting: Vec::new(),
-            read_only: Some(true),
-        })
+        Cell::Text(
+            TextCell::builder()
+                .id(id)
+                .content(content)
+                .formatting(Vec::new())
+                .read_only(true)
+                .build(),
+        )
     }
 
     pub(crate) fn try_into_cells(self) -> Result<Vec<Cell>, Error> {
-        let status_cell = Cell::Code(CodeCell {
-            id: "status".to_string(),
-            content: self.status,
-            syntax: Some("json".to_string()),
-            read_only: Some(true),
-        });
+        let status_cell = Cell::Code(
+            CodeCell::builder()
+                .id("status".to_string())
+                .content(self.status)
+                .syntax("json".to_string())
+                .read_only(true)
+                .build(),
+        );
         let headers_cell = self.headers.as_ref().map(|headers| {
-            Cell::Code(CodeCell {
-                id: "headers".to_string(),
-                content: format!("{headers:#?}"),
-                syntax: Some("json".to_string()),
-                read_only: Some(true),
-            })
+            Cell::Code(
+                CodeCell::builder()
+                    .id("headers".to_string())
+                    .content(format!("{headers:#?}"))
+                    .syntax("json".to_string())
+                    .read_only(true)
+                    .build(),
+            )
         });
-        let response_cell = Cell::Code(CodeCell {
-            id: "response".to_string(),
-            content: serde_json::from_slice::<Value>(self.payload.as_slice())
-                .and_then(|value| serde_json::to_string_pretty(&value))
-                .unwrap_or_else(|_| String::from_utf8_lossy(self.payload.as_slice()).to_string()),
-            syntax: Some("json".to_string()),
-            read_only: Some(true),
-        });
+        let response_cell = Cell::Code(
+            CodeCell::builder()
+                .id("response".to_string())
+                .content(
+                    serde_json::from_slice::<Value>(self.payload.as_slice())
+                        .and_then(|value| serde_json::to_string_pretty(&value))
+                        .unwrap_or_else(|_| {
+                            String::from_utf8_lossy(self.payload.as_slice()).to_string()
+                        }),
+                )
+                .syntax("json".to_string())
+                .read_only(true)
+                .build(),
+        );
         let results = {
             let mut accumulator = vec![
                 Self::text_cell("status-heading".to_string(), "Status Code".to_string()),
@@ -126,8 +138,8 @@ impl HttpsProviderResponse {
 }
 
 fn serialize_cells(cells: Vec<Cell>) -> Result<Blob, Error> {
-    Ok(Blob {
-        data: rmp_serde::to_vec_named(&cells)?.into(),
-        mime_type: CELLS_MSGPACK_MIME_TYPE.to_owned(),
-    })
+    Ok(Blob::builder()
+        .data(rmp_serde::to_vec_named(&cells)?)
+        .mime_type(CELLS_MSGPACK_MIME_TYPE.to_owned())
+        .build())
 }

--- a/providers/prometheus/src/auto_suggest.rs
+++ b/providers/prometheus/src/auto_suggest.rs
@@ -63,10 +63,12 @@ pub async fn query_suggestions(query_data: Blob, config: Config) -> Result<Blob>
         .data
         .into_iter()
         .filter_map(|(name, values)| {
-            values.into_iter().next().map(|value| Suggestion {
-                from,
-                text: name,
-                description: value.help,
+            values.into_iter().next().map(|value| {
+                Suggestion::builder()
+                    .from(from)
+                    .text(name)
+                    .description(value.help)
+                    .build()
             })
         })
         .collect();
@@ -83,18 +85,20 @@ pub async fn query_suggestions(query_data: Blob, config: Config) -> Result<Blob>
     }
     for &function in PROM_QL_FUNCTIONS {
         if identifier.is_empty() || function.contains(identifier) {
-            suggestions.push(Suggestion {
-                from,
-                text: function.to_owned(),
-                description: Some("Function".to_owned()),
-            })
+            suggestions.push(
+                Suggestion::builder()
+                    .from(from)
+                    .text(function.to_owned())
+                    .description(Some("Function".to_owned()))
+                    .build(),
+            )
         }
     }
 
-    Ok(Blob {
-        data: rmp_serde::to_vec_named(&suggestions)?.into(),
-        mime_type: SUGGESTIONS_MSGPACK_MIME_TYPE.to_owned(),
-    })
+    Ok(Blob::builder()
+        .data(rmp_serde::to_vec_named(&suggestions)?)
+        .mime_type(SUGGESTIONS_MSGPACK_MIME_TYPE.to_owned())
+        .build())
 }
 
 /// Extracts the identifier and starting offset that is currently being typed from the query. This

--- a/providers/prometheus/src/lib.rs
+++ b/providers/prometheus/src/lib.rs
@@ -83,8 +83,8 @@ async fn check_status(config: Config) -> Result<Blob> {
     )
     .await?;
 
-    Ok(Blob {
-        mime_type: STATUS_MIME_TYPE.to_owned(),
-        data: "ok".into(),
-    })
+    Ok(Blob::builder()
+        .mime_type(STATUS_MIME_TYPE.to_owned())
+        .data("ok")
+        .build())
 }

--- a/providers/prometheus/src/prometheus.rs
+++ b/providers/prometheus/src/prometheus.rs
@@ -36,11 +36,11 @@ pub struct PrometheusPoint(f64, String);
 impl PrometheusPoint {
     pub fn to_metric(&self) -> Result<Metric, ParseFloatError> {
         let time = SystemTime::UNIX_EPOCH + Duration::from_millis((self.0 * 1000.0) as u64);
-        Ok(Metric {
-            time: Timestamp::from(time),
-            value: self.1.parse()?,
-            otel: OtelMetadata::default(),
-        })
+        Ok(Metric::builder()
+            .time(Timestamp::from(time))
+            .value(self.1.parse()?)
+            .otel(OtelMetadata::default())
+            .build())
     }
 }
 
@@ -59,12 +59,12 @@ impl RangeVector {
             .into_iter()
             .map(|value| value.to_metric())
             .collect::<Result<_, _>>()?;
-        Ok(Timeseries {
-            name,
-            labels,
-            metrics,
-            otel: OtelMetadata::default(),
-            visible: true,
-        })
+        Ok(Timeseries::builder()
+            .name(name)
+            .labels(labels)
+            .metrics(metrics)
+            .otel(OtelMetadata::default())
+            .visible(true)
+            .build())
     }
 }

--- a/providers/sample/src/lib.rs
+++ b/providers/sample/src/lib.rs
@@ -108,18 +108,19 @@ fn create_cells(query_type: String, response: Blob) -> Result<Vec<Cell>> {
             },
     } = ShowcaseCustomData::parse_blob(response)?;
 
-    Ok(vec![Cell::Text(TextCell {
-        id: "result".to_owned(),
-        content: format!(
-            "Your query was: {query}\n\
+    Ok(vec![Cell::Text(
+        TextCell::builder()
+            .id("result".to_owned())
+            .content(format!(
+                "Your query was: {query}\n\
             Your time range: {from} - {to}\n\
             Live mode was {live}\n\
             Provided tags: {:?}",
-            tags.split('\n').collect::<Vec<_>>()
-        ),
-        formatting: Formatting::default(),
-        read_only: None,
-    })])
+                tags.split('\n').collect::<Vec<_>>()
+            ))
+            .formatting(Formatting::default())
+            .build(),
+    )])
 }
 
 /// The most basic of health-check functions: Always returns "ok".
@@ -137,12 +138,12 @@ fn create_cells(query_type: String, response: Blob) -> Result<Vec<Cell>> {
 /// the provider doesn't support health checks, and the provider is assumed to
 /// be always available.
 fn check_status() -> Result<Blob> {
-    ProviderStatus {
-        status: Ok(()),
-        version: COMMIT_HASH.to_owned(),
-        built_at: BUILD_TIMESTAMP.to_owned(),
-    }
-    .to_blob()
+    ProviderStatus::builder()
+        .status(Ok(()))
+        .version(COMMIT_HASH.to_owned())
+        .built_at(BUILD_TIMESTAMP.to_owned())
+        .build()
+        .to_blob()
 }
 
 /// This showcase shows how to return cells directly, without the need for


### PR DESCRIPTION
# Description

Follow the rewrite of Fiberplane models to
use builders instead of exhaustive structs and
tuples.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] ~~The feature is tested.~~
- [x] ~~The CHANGELOG is updated.~~
