### PR TITLE
Fix crates-io published version parsing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          target: wasm32-unknown-unknown
           override: true
 
       - name: Compile providers

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -176,7 +176,7 @@ def set_cargo_manifests_git_version(registry: str):
             # it refuses to downgrade packages (the version numbers don't really match anything
             # between crates-io and the artifactory)
             subprocess.run(
-                f'dasel put -f Cargo.toml -s ".package.version" -v "={version}"',
+                f'dasel put -f Cargo.toml -s ".package.version" -v "{version}"',
                 cwd=crate_dir,
                 check=True,
                 shell=True,


### PR DESCRIPTION
# Description

The sparse index sometimes answers with one JSON object per line

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] ~~The feature is tested.~~
- [x] ~~The CHANGELOG is updated.~~
