### PR TITLE
Rename Event in the providers module to ProviderEvent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+target/
 **/target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 [[package]]
 name = "base64uuid"
 version = "1.0.0"
-source = "git+ssh://git@github.com/fiberplane/fiberplane.git?branch=main#70f6c5272fa4f24f46fe0e353187d95a37f97499"
 dependencies = [
  "base64",
  "serde",
@@ -398,7 +397,6 @@ dependencies = [
 [[package]]
 name = "fiberplane-models"
 version = "1.0.0-beta.1"
-source = "git+ssh://git@github.com/fiberplane/fiberplane.git?branch=main#70f6c5272fa4f24f46fe0e353187d95a37f97499"
 dependencies = [
  "base64",
  "base64uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,6 @@ vergen = { version = "7.4.2", default-features = false, features = [
 #fp-bindgen-support = { path = "../fp-bindgen/fp-bindgen-support" }
 #fp-bindgen = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "main" }
 #fp-bindgen-support = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "main" }
+
+[patch.'ssh://git@github.com/fiberplane/fiberplane.git']
+fiberplane-models = { path = "../fiberplane/fiberplane-models" }

--- a/fiberplane-pdk/src/types/provider_data_types.rs
+++ b/fiberplane-pdk/src/types/provider_data_types.rs
@@ -2,8 +2,8 @@ use crate as fiberplane_pdk; // To satisfy the `ProviderData` macro output.
 use crate::bindings::Cell;
 use crate::macros::ProviderData;
 use crate::providers::{
-    Event, Suggestion, Timeseries, CELLS_MIME_TYPE, EVENTS_MIME_TYPE, SUGGESTIONS_MIME_TYPE,
-    TIMESERIES_MIME_TYPE,
+    ProviderEvent, Suggestion, Timeseries, CELLS_MIME_TYPE, EVENTS_MIME_TYPE,
+    SUGGESTIONS_MIME_TYPE, TIMESERIES_MIME_TYPE,
 };
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +13,7 @@ pub struct Cells(pub Vec<Cell>);
 
 #[derive(Clone, Debug, Deserialize, ProviderData, Serialize)]
 #[pdk(mime_type = EVENTS_MIME_TYPE)]
-pub struct Events(pub Vec<Event>);
+pub struct Events(pub Vec<ProviderEvent>);
 
 #[derive(Clone, Debug, Deserialize, ProviderData, Serialize)]
 #[pdk(mime_type = SUGGESTIONS_MIME_TYPE)]

--- a/providers/cloudwatch/src/queries/get_log_record.rs
+++ b/providers/cloudwatch/src/queries/get_log_record.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use fiberplane_pdk::prelude::{Blob, Cell, Error, LogCell, ProviderRequest};
 use fiberplane_pdk::providers::{
-    Event, OtelMetadata, OtelSpanId, OtelTraceId, FORM_ENCODED_MIME_TYPE,
+    OtelMetadata, OtelSpanId, OtelTraceId, ProviderEvent, FORM_ENCODED_MIME_TYPE,
 };
 use std::collections::{BTreeMap, HashMap};
 use time::{
@@ -27,7 +27,7 @@ pub async fn invoke2_handler(config: Config, request: ProviderRequest) -> Result
         .and_then(try_into_blob)
 }
 
-pub fn convert_log_entry_to_event(res: HashMap<String, String>) -> Result<Event, Error> {
+pub fn convert_log_entry_to_event(res: HashMap<String, String>) -> Result<ProviderEvent, Error> {
     let time = res
         .get(TS_KEY.0)
         .and_then(|x| {
@@ -100,7 +100,7 @@ pub fn convert_log_entry_to_event(res: HashMap<String, String>) -> Result<Event,
                 .collect(),
         )
         .build();
-    Ok(Event::builder()
+    Ok(ProviderEvent::builder()
         .time(time.into())
         .end_time(None)
         .otel(otel)

--- a/providers/elasticsearch/src/lib.rs
+++ b/providers/elasticsearch/src/lib.rs
@@ -141,9 +141,9 @@ fn parse_response(
     response: SearchResponse,
     timestamp_field_names: &[&str],
     body_field_names: &[&str],
-) -> Vec<Event> {
+) -> Vec<ProviderEvent> {
     let hits = response.hits.hits.into_iter();
-    let mut log_lines: Vec<Event> = hits
+    let mut log_lines: Vec<ProviderEvent> = hits
         .filter_map(|hit| parse_hit(hit, timestamp_field_names, body_field_names))
         .collect();
     // Sort logs so the newest ones are first
@@ -151,7 +151,11 @@ fn parse_response(
     log_lines
 }
 
-fn parse_hit(hit: Hit, timestamp_field_names: &[&str], body_field_names: &[&str]) -> Option<Event> {
+fn parse_hit(
+    hit: Hit,
+    timestamp_field_names: &[&str],
+    body_field_names: &[&str],
+) -> Option<ProviderEvent> {
     let source: Map<String, Value> = hit
         .source()
         .map_err(|err| {
@@ -237,7 +241,7 @@ fn parse_hit(hit: Hit, timestamp_field_names: &[&str], body_field_names: &[&str]
         .trace_id(trace_id)
         .span_id(span_id)
         .build();
-    let event = Event::builder()
+    let event = ProviderEvent::builder()
         .title(title)
         .time(timestamp.into())
         .otel(metadata)

--- a/providers/loki/src/lib.rs
+++ b/providers/loki/src/lib.rs
@@ -97,7 +97,7 @@ async fn fetch_logs(query: LokiQuery, config: Config) -> Result<Blob> {
     let log_lines = data
         .iter()
         .flat_map(data_mapper)
-        .collect::<Result<Vec<Event>>>()
+        .collect::<Result<Vec<ProviderEvent>>>()
         .map_err(|e| Error::Data {
             message: format!("Failed to parse data, got error: {e:?}"),
         })?;
@@ -105,7 +105,7 @@ async fn fetch_logs(query: LokiQuery, config: Config) -> Result<Blob> {
     Events(log_lines).to_blob()
 }
 
-fn data_mapper(data: &Data) -> impl Iterator<Item = Result<Event>> + '_ {
+fn data_mapper(data: &Data) -> impl Iterator<Item = Result<ProviderEvent>> + '_ {
     let attributes = &data.labels;
     data.values.iter().map(move |(timestamp, value)| {
         let timestamp = i128::from_str(timestamp)
@@ -119,7 +119,7 @@ fn data_mapper(data: &Data) -> impl Iterator<Item = Result<Event>> + '_ {
             .trace_id(None)
             .span_id(None)
             .build();
-        let event = Event::builder()
+        let event = ProviderEvent::builder()
             .title(value.clone())
             .time(timestamp.into())
             .otel(metadata)

--- a/providers/loki/src/tests.rs
+++ b/providers/loki/src/tests.rs
@@ -73,7 +73,7 @@ fn test_data_mapper() {
     assert_eq!(mapped.len(), 2);
     assert_eq!(
         mapped[0],
-        Event::builder()
+        ProviderEvent::builder()
             .time(
                 OffsetDateTime::from_unix_timestamp_nanos(1_569_266_497_240_578_000)
                     .unwrap()
@@ -85,7 +85,7 @@ fn test_data_mapper() {
     );
     assert_eq!(
         mapped[1],
-        Event::builder()
+        ProviderEvent::builder()
             .time(
                 OffsetDateTime::from_unix_timestamp_nanos(1_569_266_492_548_155_000)
                     .unwrap()


### PR DESCRIPTION
This will prevent naming collision when using using these structs with fp-bindgen. Merging the conflicting structs proved to be more complicated due to the large surface area.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [ ] The feature is tested.
- [ ] The CHANGELOG is updated.
