### PR TITLE
Add create_cells() impls to elasticsearch & loki

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - id: branch
-        name: Export branch
-        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF##refs/heads/}}" >> $GITHUB_OUTPUT
-
       - name: setup-git-credentials
         uses: de-vri-es/setup-git-credentials@v2
         with:
@@ -55,6 +51,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: setup-git-credentials
+        uses: de-vri-es/setup-git-credentials@v2
+        with:
+          credentials: "https://fiberplanebot:${{ secrets.PRIVATE_GITHUB_TOKEN }}@github.com/"
 
       - name: Cache Rust dependencies
         uses: actions/cache@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ changes if the major version hasn't changed.
 - Fixed required fields in schemas generated using the `QuerySchema` macro.
 - Fixed support for the `checked_by_default` and `supports_suggestions`
   annotations in the `ConfigSchema` and `QuerySchema` macros.
+- Fixed lacking `create_cells()` implementation for Elasticsearch and Loki providers
 
 ## [1.0.0-beta.1] - 2023-02-14
 

--- a/providers/elasticsearch/src/lib.rs
+++ b/providers/elasticsearch/src/lib.rs
@@ -54,6 +54,16 @@ pdk_query_types! {
     }
 }
 
+#[pdk_export]
+fn create_cells(query_type: String, _response: Blob) -> Result<Vec<Cell>> {
+    log(format!("Creating cells for query type: {query_type}"));
+
+    match query_type.as_str() {
+        EVENTS_QUERY_TYPE => create_log_cell(),
+        _ => Err(Error::UnsupportedRequest),
+    }
+}
+
 async fn fetch_logs(query: ElasticQuery, config: ElasticConfig) -> Result<Blob> {
     let mut url = config.parse_url()?;
 
@@ -307,4 +317,15 @@ fn timestamp_to_rfc3339(timestamp: OffsetDateTime) -> Result<String> {
                 .message(format!("Invalid timestamp in range: {err}"))
                 .build()],
         })
+}
+
+pub fn create_log_cell() -> Result<Vec<Cell>> {
+    let logs_cell = Cell::Log(
+        LogCell::builder()
+            .id("query-results".to_string())
+            .data_links(vec![format!("cell-data:{EVENTS_MIME_TYPE},self")])
+            .hide_similar_values(false)
+            .build(),
+    );
+    Ok(vec![logs_cell])
 }

--- a/providers/loki/src/lib.rs
+++ b/providers/loki/src/lib.rs
@@ -59,6 +59,16 @@ struct Data {
     values: Vec<(String, String)>,
 }
 
+#[pdk_export]
+fn create_cells(query_type: String, _response: Blob) -> Result<Vec<Cell>> {
+    log(format!("Creating cells for query type: {query_type}"));
+
+    match query_type.as_str() {
+        EVENTS_QUERY_TYPE => create_log_cell(),
+        _ => Err(Error::UnsupportedRequest),
+    }
+}
+
 async fn fetch_logs(query: LokiQuery, config: Config) -> Result<Blob> {
     // Convert unix epoch in seconds to epoch in nanoseconds
     let from = (query.time_range.from.unix_timestamp_nanos()).to_string();
@@ -151,4 +161,15 @@ async fn check_status(request: ProviderRequest) -> Result<Blob> {
         .built_at(BUILD_TIMESTAMP.to_owned())
         .build()
         .to_blob()
+}
+
+pub fn create_log_cell() -> Result<Vec<Cell>> {
+    let logs_cell = Cell::Log(
+        LogCell::builder()
+            .id("query-results".to_string())
+            .data_links(vec![format!("cell-data:{EVENTS_MIME_TYPE},self")])
+            .hide_similar_values(false)
+            .build(),
+    );
+    Ok(vec![logs_cell])
 }


### PR DESCRIPTION
# Description

This pr adds `create_cells()` to elasticsearch and loki providers. This resolves [FP-3078](https://linear.app/fiberplane/issue/FP-3078/elasticsearch-direct-access-doesnt-work).

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] The feature is tested.
- [x] The CHANGELOG is updated.
