### PR TITLE
Rename release job

### DIFF
--- a/.github/workflows/manual_publish.yml
+++ b/.github/workflows/manual_publish.yml
@@ -40,5 +40,5 @@ jobs:
           command: login
           args: ${{ secrets.CRATES_TOKEN }}
 
-      - name: Publish crates
+      - name: Publish PDK crates
         run: cargo xtask publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Release
 
 on:
   release:
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -61,5 +61,5 @@ jobs:
           command: login
           args: ${{ secrets.CRATES_TOKEN }}
 
-      - name: Publish crates
+      - name: Publish PDK crates
         run: cargo xtask publish


### PR DESCRIPTION
# Description

The CI job for creating releases was still called "build", so there were two "build" workflows. Fixed it.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- ~~[ ] The feature is tested.~~
- ~~[ ] The CHANGELOG is updated.~~
