### PR TITLE
Implement instant queries in Prometheus

### DIFF
--- a/providers/prometheus/src/auto_suggest.rs
+++ b/providers/prometheus/src/auto_suggest.rs
@@ -1,4 +1,4 @@
-use super::{constants::*, prometheus::*};
+use super::prometheus::*;
 use fiberplane_pdk::prelude::*;
 use grafana_common::{query_direct_and_proxied, Config};
 
@@ -94,10 +94,7 @@ pub async fn query_suggestions(query: AutoSuggestRequest, config: Config) -> Res
         }
     }
 
-    Ok(Blob::builder()
-        .data(rmp_serde::to_vec_named(&suggestions)?)
-        .mime_type(SUGGESTIONS_MSGPACK_MIME_TYPE.to_owned())
-        .build())
+    Suggestions(suggestions).to_blob()
 }
 
 /// Extracts the identifier and starting offset that is currently being typed from the query. This

--- a/providers/prometheus/src/constants.rs
+++ b/providers/prometheus/src/constants.rs
@@ -1,8 +1,5 @@
-use const_format::formatcp;
-use fiberplane_pdk::providers::{SUGGESTIONS_MIME_TYPE, TIMESERIES_MIME_TYPE};
-
-pub const SUGGESTIONS_MSGPACK_MIME_TYPE: &str = formatcp!("{SUGGESTIONS_MIME_TYPE}+msgpack");
-pub const TIMESERIES_MSGPACK_MIME_TYPE: &str = formatcp!("{TIMESERIES_MIME_TYPE}+msgpack");
+pub const INSTANTS_MIME_TYPE: &str = "application/vnd.fiberplane.instants";
+pub const INSTANTS_QUERY_TYPE: &str = "x-instants";
 
 pub const QUERY_PARAM_NAME: &str = "query";
 

--- a/providers/prometheus/src/instants.rs
+++ b/providers/prometheus/src/instants.rs
@@ -1,0 +1,42 @@
+use super::{constants::*, prometheus::*};
+use fiberplane_models::blobs::Blob;
+use fiberplane_models::providers::Metric;
+use fiberplane_pdk::prelude::*;
+use grafana_common::{query_direct_and_proxied, Config};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, ProviderData, Serialize)]
+#[pdk(mime_type = INSTANTS_MIME_TYPE)]
+pub struct Instants(pub Vec<Instant>);
+
+/// A single data-point in time, with meta-data about the metric it was taken from.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Instant {
+    pub name: String,
+    pub labels: BTreeMap<String, String>,
+    pub metric: Metric,
+}
+
+pub async fn query_instants(request: ProviderRequest) -> Result<Blob> {
+    let response: PrometheusResponse = query_direct_and_proxied(
+        &Config::parse(request.config)?,
+        "prometheus",
+        "api/v1/query",
+        Some(request.query_data),
+    )
+    .await?;
+
+    let PrometheusData::Vector(instants) = response.data else {
+        return Err(Error::Data {
+            message: "Expected a vector of instants".to_string(),
+        })
+    };
+
+    instants
+        .into_iter()
+        .map(InstantVector::into_instant)
+        .collect::<Result<Vec<_>>>()
+        .and_then(|instants| Instants(instants).to_blob())
+}

--- a/providers/prometheus/src/lib.rs
+++ b/providers/prometheus/src/lib.rs
@@ -1,11 +1,14 @@
 mod auto_suggest;
 mod constants;
+mod instants;
 mod prometheus;
 mod timeseries;
 
 use auto_suggest::query_suggestions;
+use constants::{INSTANTS_MIME_TYPE, INSTANTS_QUERY_TYPE};
 use fiberplane_pdk::prelude::*;
 use grafana_common::{query_direct_and_proxied, Config};
+use instants::query_instants;
 use serde_json::Value;
 use std::env;
 use timeseries::{create_graph_cell, query_series, TimeseriesQuery};
@@ -14,8 +17,13 @@ static COMMIT_HASH: &str = env!("VERGEN_GIT_SHA");
 static BUILD_TIMESTAMP: &str = env!("VERGEN_BUILD_TIMESTAMP");
 
 pdk_query_types! {
+    INSTANTS_QUERY_TYPE => {
+        handler: query_instants(ProviderRequest).await,
+        supported_mime_types: [INSTANTS_MIME_TYPE]
+    },
     TIMESERIES_QUERY_TYPE => {
         handler: query_series(TimeseriesQuery, Config).await,
+        label: "Prometheus chart",
         supported_mime_types: [TIMESERIES_MIME_TYPE]
     },
     STATUS_QUERY_TYPE => {


### PR DESCRIPTION
# Description

Adds support for instant queries in the Prometheus provider. This does not map to any cells yet, so it remains hidden from Studio.

Also did some minor Prometheus updates to use the PDK more where it made sense.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] The feature is tested.
- ~~[ ] The CHANGELOG is updated.~~
