### PR TITLE
Decrease step size for prometheus queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ changes if the major version hasn't changed.
 
 ## [Unreleased]
 
+- Prometheus provider: decrease step size in order to add more details to lines in graphs.
+
 ### Added
 
 - Added support for `ArrayField` schema specification. As long as `T` has a
   `QuerySchema` derive, you can use `Vec<T>` in structs that derive
-  `QuerySchema`.  Serialization to URL-encoded query uses the ["bracket"
+  `QuerySchema`. Serialization to URL-encoded query uses the ["bracket"
   notation](https://docs.rs/serde-querystring/0.2.1/serde_querystring/index.html#brackets-mode).
   (#31)
 

--- a/providers/prometheus/src/timeseries.rs
+++ b/providers/prometheus/src/timeseries.rs
@@ -176,11 +176,12 @@ fn step_to_seconds(step: StepSize) -> u32 {
 }
 
 /// Returns the step to fetch from the given duration in seconds. We attempt
-/// to maintain roughly 30 steps for whatever the duration is, so that for a
-/// duration of one hour, we fetch per 2 minutes, and for a duration of one
-/// minute, we fetch per 2 seconds.
+/// to maintain roughly 120 steps for whatever the duration is, so that for a
+/// duration of one hour, we fetch per 30 seconds, however for a duration of one
+/// minute, we fetch per 1 seconds (as the step value is rounded up to a 
+/// full unit).
 fn step_for_range(from: f64, to: f64) -> StepSize {
-    let mut step = (to - from) / 30.0;
+    let mut step = (to - from) / 120.0;
     let mut unit = StepUnit::Seconds;
     if step >= 60.0 {
         step /= 60.0;
@@ -192,7 +193,7 @@ fn step_for_range(from: f64, to: f64) -> StepSize {
     }
 
     StepSize {
-        amount: f64::ceil(2.0 * step) as u32,
+        amount: f64::ceil(step) as u32,
         unit,
     }
 }

--- a/providers/prometheus/src/timeseries.rs
+++ b/providers/prometheus/src/timeseries.rs
@@ -178,7 +178,7 @@ fn step_to_seconds(step: StepSize) -> u32 {
 /// Returns the step to fetch from the given duration in seconds. We attempt
 /// to maintain roughly 120 steps for whatever the duration is, so that for a
 /// duration of one hour, we fetch per 30 seconds, however for a duration of one
-/// minute, we fetch per 1 seconds (as the step value is rounded up to a 
+/// minute, we fetch per 1 seconds (as the step value is rounded up to a
 /// full unit).
 fn step_for_range(from: f64, to: f64) -> StepSize {
     let mut step = (to - from) / 120.0;


### PR DESCRIPTION
# Description

Right now studio (and also the vscode extension for autometrics) generate 17 data points for a graph (it aims for 15 but also expands the range slightly in order to be able to draw lines neatly at the beginning/end of the graph and so 17 data points are actually returned). 

This PR expands that to 120 (+ plus 2 extra due to the use of a slightly expanded range). 

So this means that instead of:
<img width="1072" alt="image" src="https://github.com/fiberplane/providers/assets/473804/4bf17fc3-5af7-4e73-aa47-8092d63ea8aa">

You get:
<img width="1055" alt="image" src="https://github.com/fiberplane/providers/assets/473804/b5033749-5f74-4e50-a38c-1664826a7e9c">

This is more inline with what for instance prometheus or grafana would produce without containing so many points it's hard to see individual data points

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] The feature is tested.
- [x] The CHANGELOG is updated.
