### PR TITLE
Bundle artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Compile providers
         run: |
-          cargo xtask build all
+          cargo xtask build all --exclude=sample
 
       - name: Save providers
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,13 +40,7 @@ jobs:
         with:
           allow_override: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          files: >
-            artifacts/cloudwatch.wasm
-            artifacts/elasticsearch.wasm
-            artifacts/https.wasm
-            artifacts/loki.wasm
-            artifacts/prometheus.wasm
-            artifacts/sentry.wasm
+          files: providers:artifacts/
 
       - name: Cargo login
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ changes if the major version hasn't changed.
 
 ## [Unreleased]
 
+### Added
+
+- Added provider for Parseable.
+
+## [1.0.0-beta.3] - 2023-06-14
+
 - Prometheus provider: decrease step size in order to add more details to lines in graphs.
 
 ### Added


### PR DESCRIPTION
# Description

The previous release had all the providers attached separately, like this: https://github.com/fiberplane/providers/releases/tag/v2023.23.0-beta.3

That looks a bit awkward, so now we bundle the providers into a single `.tgz` instead. That should also make sure the new Parseable provider gets included, and future providers will be included without needing to update workflows.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- ~~[ ] The feature is tested.~~
- [x] The CHANGELOG is updated.
