### PR TITLE
Bump minor version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "fiberplane-pdk"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 dependencies = [
  "fiberplane-models",
  "fiberplane-pdk-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ repository = "https://github.com/fiberplane/providers"
 [workspace.dependencies]
 fiberplane-ci = { git = "ssh://git@github.com/fiberplane/fiberplane.git", branch = "main" }
 fiberplane-models = { version = "1.0.0-beta.6" }
-fiberplane-pdk = { version = "1.0.0-beta.6", path = "fiberplane-pdk" }
-fiberplane-pdk-macros = { version = "1.0.0-beta.6", path = "fiberplane-pdk-macros" }
+fiberplane-pdk = { version = "1.0.0-beta.7", path = "fiberplane-pdk" }
+fiberplane-pdk-macros = { version = "1.0.0-beta.7", path = "fiberplane-pdk-macros" }
 fiberplane-provider-bindings = { version = "2.0.0-beta.6" }
 fp-bindgen = { version = "3.0.0" }
 fp-bindgen-support = { version = "3.0.0" }

--- a/fiberplane-pdk-macros/Cargo.toml
+++ b/fiberplane-pdk-macros/Cargo.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 license = { workspace = true }
 repository = { workspace = true }
 

--- a/fiberplane-pdk/Cargo.toml
+++ b/fiberplane-pdk/Cargo.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 license = { workspace = true }
 repository = { workspace = true }
 


### PR DESCRIPTION
This PR bumps the version numbers so they match the next release.
Please verify the version numbers are correct, and update the CHANGELOG manually. You
should merge this PR ASAP, but no later than before the next release cycle starts.

# Checklist

- [ ] Version numbers are correct
- [ ] `CHANGELOG.md` has been updated