### PR TITLE
Bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ crates do not strictly follow _SemVer_ although their versioning remains
 _compatible with_ SemVer, i.e. they will not contain breaking changes if the
 major version hasn't changed.
 
-## [1.0.0-beta.8]
+## [1.0.0-beta.9]
+
+## [1.0.0-beta.8] - 2024-02-05
+
+- Updated dependencies
 
 ## [1.0.0-beta.7] - 2024-01-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "fiberplane-pdk"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "fiberplane-models",
  "fiberplane-pdk-macros",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "fiberplane-pdk-macros"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "Inflector",
  "fiberplane-models",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ repository = "https://github.com/fiberplane/providers"
 [workspace.dependencies]
 fiberplane-ci = { git = "ssh://git@github.com/fiberplane/fiberplane.git", branch = "main" }
 fiberplane-models = { version = "1.0.0-beta.6" }
-fiberplane-pdk = { version = "1.0.0-beta.8", path = "fiberplane-pdk" }
-fiberplane-pdk-macros = { version = "1.0.0-beta.8", path = "fiberplane-pdk-macros" }
+fiberplane-pdk = { version = "1.0.0-beta.9", path = "fiberplane-pdk" }
+fiberplane-pdk-macros = { version = "1.0.0-beta.9", path = "fiberplane-pdk-macros" }
 fiberplane-provider-bindings = { version = "2.0.0-beta.6" }
 fp-bindgen = { version = "3.0.0" }
 fp-bindgen-support = { version = "3.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["providers/.cargo"]
 authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2021"
 rust-version = "1.65"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.8"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fiberplane/providers"
 

--- a/fiberplane-pdk-macros/Cargo.toml
+++ b/fiberplane-pdk-macros/Cargo.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 license = { workspace = true }
 repository = { workspace = true }
 

--- a/fiberplane-pdk/Cargo.toml
+++ b/fiberplane-pdk/Cargo.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 license = { workspace = true }
 repository = { workspace = true }
 


### PR DESCRIPTION
This PR bumps the version numbers so they match the next release.
Please verify the version numbers are correct, and update the CHANGELOG manually. You
should merge this PR ASAP, but no later than before the next release cycle starts.

# Checklist

- [x] Version numbers are correct
- [x] `CHANGELOG.md` has been updated