### PR TITLE
switch to using `softprops/action-gh-release`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,10 @@ jobs:
           cargo xtask build all --exclude=sample
 
       - name: Attach providers to release
-        uses: meeDamian/github-release@2.0
+        uses: softprops/action-gh-release@v1
         with:
-          allow_override: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          files: providers:artifacts/
+          files: artifacts/*
+          fail_on_unmatched_files: true
 
       - name: Cargo login
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
# Description

this now uses the same action as we used with autometrics/am. i think using this action makes more sense because it is updated (last update as of pr creation date 4 days ago) while the old one was last updated 4 years ago

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] ~~The feature is tested.~~
- [x] ~~The CHANGELOG is updated.~~
