### PR TITLE
Bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ crates do not strictly follow _SemVer_ although their versioning remains
 _compatible with_ SemVer, i.e. they will not contain breaking changes if the
 major version hasn't changed.
 
+## unreleased
+
+## [1.0.0-beta.13] - 2024-03-01
+
+- Updated dependencies
+
 ## [1.0.0-beta.12] - 2024-02-23
 
 - Updated dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "fiberplane-pdk"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 dependencies = [
  "fiberplane-models",
  "fiberplane-pdk-macros",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "fiberplane-pdk-macros"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 dependencies = [
  "Inflector",
  "fiberplane-models",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ repository = "https://github.com/fiberplane/providers"
 [workspace.dependencies]
 fiberplane-ci = { git = "ssh://git@github.com/fiberplane/fiberplane.git", branch = "main" }
 fiberplane-models = { version = "1.0.0-beta.11" }
-fiberplane-pdk = { version = "1.0.0-beta.12", path = "fiberplane-pdk" }
-fiberplane-pdk-macros = { version = "1.0.0-beta.12", path = "fiberplane-pdk-macros" }
+fiberplane-pdk = { version = "1.0.0-beta.13", path = "fiberplane-pdk" }
+fiberplane-pdk-macros = { version = "1.0.0-beta.13", path = "fiberplane-pdk-macros" }
 fiberplane-provider-bindings = { version = "2.0.0-beta.11" }
 fp-bindgen = { version = "3.0.0" }
 fp-bindgen-support = { version = "3.0.0" }

--- a/fiberplane-pdk-macros/Cargo.toml
+++ b/fiberplane-pdk-macros/Cargo.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 license = { workspace = true }
 repository = { workspace = true }
 

--- a/fiberplane-pdk/Cargo.toml
+++ b/fiberplane-pdk/Cargo.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 license = { workspace = true }
 repository = { workspace = true }
 


### PR DESCRIPTION
This PR bumps the version numbers so they match the next release.
Please verify the version numbers are correct, and update the CHANGELOG manually. You
should merge this PR ASAP, but no later than before the next release cycle starts.

# Checklist

- [x] Version numbers are correct
- [x] `CHANGELOG.md` has been updated